### PR TITLE
Add number of pictures in one album

### DIFF
--- a/apps/webapp/pages/album/[...slug].tsx
+++ b/apps/webapp/pages/album/[...slug].tsx
@@ -25,6 +25,7 @@ import { AlbumCard } from "../../src/component/AlbumCard";
 import { AlbumGrid } from "../../src/component/AlbumGrid";
 import { AlbumGridListTile } from "../../src/component/AlbumGridListTile";
 import { Thumbnail } from "../../src/component/Thumbnail";
+import {RightPanel} from "../../src/module/album/RightPanel";
 
 type Props = {};
 type InitialProps = { namespacesRequired: string[] };
@@ -79,8 +80,8 @@ const AlbumPage: NextPage<Props, InitialProps> = () => {
   });
 
   return (
-    <Layout>
-      <Box bgcolor="white" padding={gutter}>
+    <Layout rightComponent={<RightPanel nbPhotos={data?.getAlbum.photos.length} />}>
+      <Box padding={gutter}>
         <Box paddingBottom={gutter} id="BreadcrumbBox">
           <Breadcrumbs aria-label="breadcrumb">
             <Link href="/" key="repo">

--- a/apps/webapp/pages/album/[...slug].tsx
+++ b/apps/webapp/pages/album/[...slug].tsx
@@ -25,7 +25,7 @@ import { AlbumCard } from "../../src/component/AlbumCard";
 import { AlbumGrid } from "../../src/component/AlbumGrid";
 import { AlbumGridListTile } from "../../src/component/AlbumGridListTile";
 import { Thumbnail } from "../../src/component/Thumbnail";
-import {RightPanel} from "../../src/module/album/RightPanel";
+import { RightPanel } from "../../src/module/album/RightPanel";
 
 type Props = {};
 type InitialProps = { namespacesRequired: string[] };
@@ -80,7 +80,9 @@ const AlbumPage: NextPage<Props, InitialProps> = () => {
   });
 
   return (
-    <Layout rightComponent={<RightPanel nbPhotos={data?.getAlbum.photos.length} />}>
+    <Layout
+      rightComponent={<RightPanel nbPhotos={data?.getAlbum.photos.length} />}
+    >
       <Box padding={gutter}>
         <Box paddingBottom={gutter} id="BreadcrumbBox">
           <Breadcrumbs aria-label="breadcrumb">

--- a/apps/webapp/src/module/album/RightPanel.tsx
+++ b/apps/webapp/src/module/album/RightPanel.tsx
@@ -6,6 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import Skeleton from "@material-ui/lab/Skeleton";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { styled } from "@material-ui/core";
+import { useTranslation } from "react-i18next";
 
 type Props = {
   nbPhotos?: number;
@@ -23,21 +24,27 @@ const StyledExpansionPanelSummary = styled(ExpansionPanelSummary)(
   })
 );
 
-export const RightPanel: React.FC<Props> = ({ nbPhotos }) => (
-  <StyledExpansionPanel defaultExpanded>
-    <StyledExpansionPanelSummary
-      expandIcon={<ExpandMoreIcon />}
-      aria-controls="panel1a-content"
-      id="panel1a-header"
-    >
-      <Typography>Information</Typography>
-    </StyledExpansionPanelSummary>
-    <ExpansionPanelDetails>
-      {nbPhotos ? (
-        <Typography variant="body2">{nbPhotos} photos</Typography>
-      ) : (
-        <Skeleton width="100%" />
-      )}
-    </ExpansionPanelDetails>
-  </StyledExpansionPanel>
-);
+export const RightPanel: React.FC<Props> = ({ nbPhotos }) => {
+  const { t } = useTranslation("common");
+
+  return (
+    <StyledExpansionPanel defaultExpanded>
+      <StyledExpansionPanelSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="panel1a-content"
+        id="panel1a-header"
+      >
+        <Typography>{t("information")}</Typography>
+      </StyledExpansionPanelSummary>
+      <ExpansionPanelDetails>
+        {nbPhotos ? (
+          <Typography variant="body2">
+            {t("photos", { count: nbPhotos })}
+          </Typography>
+        ) : (
+          <Skeleton width="100%" />
+        )}
+      </ExpansionPanelDetails>
+    </StyledExpansionPanel>
+  );
+};

--- a/apps/webapp/src/module/album/RightPanel.tsx
+++ b/apps/webapp/src/module/album/RightPanel.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import Typography from "@material-ui/core/Typography";
+import Skeleton from "@material-ui/lab/Skeleton";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { styled } from "@material-ui/core";
+
+type Props = {
+  nbPhotos?: number;
+};
+
+const StyledExpansionPanel = styled(ExpansionPanel)(() => ({
+  background: "transparent",
+  boxShadow: "none"
+}));
+
+const StyledExpansionPanelSummary = styled(ExpansionPanelSummary)(
+  ({ theme }) => ({
+    background: theme.palette.grey["200"],
+    boxShadow: "none"
+  })
+);
+
+export const RightPanel: React.FC<Props> = ({ nbPhotos }) => (
+  <StyledExpansionPanel defaultExpanded>
+    <StyledExpansionPanelSummary
+      expandIcon={<ExpandMoreIcon />}
+      aria-controls="panel1a-content"
+      id="panel1a-header"
+    >
+      <Typography>Information</Typography>
+    </StyledExpansionPanelSummary>
+    <ExpansionPanelDetails>
+      {nbPhotos ? (
+        <Typography variant="body2">{nbPhotos} photos</Typography>
+      ) : (
+        <Skeleton width="100%" />
+      )}
+    </ExpansionPanelDetails>
+  </StyledExpansionPanel>
+);

--- a/apps/webapp/src/module/layout/Layout.tsx
+++ b/apps/webapp/src/module/layout/Layout.tsx
@@ -12,26 +12,32 @@ interface LayoutProps {
 
 const RawLayout: React.FC<LayoutProps> = ({
   leftComponent,
-  // rightComponent,
+  rightComponent,
   children
 }) => {
   const { user, logout } = useCurrentUser();
 
   return (
-    <>
-      <Container>
-        <Box display="flex" minHeight="100vh">
-          <Box width={200} minHeight="100%">
-            <Button onClick={logout}>{user?.name}</Button>
-            {leftComponent}
-          </Box>
-          <Box flex={1} minHeight="100%" bgcolor="white" boxShadow={1}>
-            {children}
-          </Box>
-          {/* <Box width={200}>{rightComponent}</Box> */}
+    <div style={{ width: "100%" }}>
+      <Box display="flex" minHeight="100vh">
+        <Box width={200} minHeight="100%" p={2}>
+          <Button onClick={logout}>{user?.name}</Button>
+          {leftComponent}
         </Box>
-      </Container>
-    </>
+        <Box
+          flex={1}
+          minHeight="100%"
+          bgcolor="white"
+          boxShadow={4}
+          zIndex={100}
+        >
+          <Container>{children}</Container>
+        </Box>
+        <Box width={200} minHeight="100%">
+          {rightComponent}
+        </Box>
+      </Box>
+    </div>
   );
 };
 

--- a/apps/webapp/static/locales/en/common.json
+++ b/apps/webapp/static/locales/en/common.json
@@ -6,5 +6,8 @@
     "next": "Next",
     "email": "Email address",
     "emailSent": "Congratulations, you're almost there! \uD83C\uDF8A An email has been sent to your address. Click on the link to finish logging in!"
-  }
+  },
+  "information": "Information",
+  "photos": "{{count}} photo",
+  "photos_plural": "{{count}} photos"
 }


### PR DESCRIPTION
## Description

Add the number of pictures in the album info panel.

![image](https://user-images.githubusercontent.com/219680/71647189-c5143400-2cc0-11ea-9ed2-f5b972f25709.png)

<!-- https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- Uncomment line below if it closes or relates to an opened issue -->
<!-- Closes #XXX -->

## How to test?

- Check-out this branch.
- Go to an album and check the display.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/vickev/howdypix/blob/master/.github/CONTRIBUTING.md) guide
- [x] I updated the README according to my changes
- [x] I have translated all my texts, if applicable
- [x] I have used `debug()` to help debug the feature, if applicable
- [x] I have added tests that prove my fix is effective or that my feature works, if applicable
